### PR TITLE
Fix artifact name

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ repositories {
     jcenter()
 }
 
-compile 'com.aungkyawpaing.geoshi:geoshi-converter:0.0.2'
+compile 'com.aungkyawpaing.geoshi:geoshi-adapter:0.0.2'
 ```
 
 ## License


### PR DESCRIPTION
As per the real name https://jcenter.bintray.com/com/aungkyawpaing/geoshi/geoshi-adapter/ 

(This made me scratch my head for a while when trying to make use of the library)